### PR TITLE
feat(pwa): create `manifest.json`

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,29 +8,46 @@ export default defineNuxtConfig({
 
       meta: [
         { charset: "utf-8" },
-        
-        { hid: "og:site_name", property: "og:site_name", content: "わかめナビ🌱" },
+
+        {
+          hid: "og:site_name",
+          property: "og:site_name",
+          content: "わかめナビ🌱",
+        },
         { hid: "og:title", property: "og:title", content: "わかめナビ🌱" },
-        { hid: "og:description", property: "og:description", content: "埼玉大学周辺を走るバスの運行情報を確認することができます。" },
+        {
+          hid: "og:description",
+          property: "og:description",
+          content: "埼玉大学周辺を走るバスの運行情報を確認することができます。",
+        },
         { hid: "og:type", property: "og:type", content: "website" },
-        { hid: "og:url", property: "og:url", content: "https://wakame-navi.vercel.app/" },
-        { hid: "og:image", property: "og:image", content: "https://wakame-navi.vercel.app/assets/ogp_1200x600.png" },
+        {
+          hid: "og:url",
+          property: "og:url",
+          content: "https://wakame-navi.vercel.app/",
+        },
+        {
+          hid: "og:image",
+          property: "og:image",
+          content: "https://wakame-navi.vercel.app/assets/ogp_1200x600.png",
+        },
         { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:site", content: "@SU_Mentsuyu" }
+        { name: "twitter:site", content: "@SU_Mentsuyu" },
       ],
 
       link: [
         { rel: "icon", type: "image/x-icon", href: "/favicon.png" },
-      ]
-    }
+        { rel: "manifest", href: "/manifest.json" },
+      ],
+    },
   },
-  
+
   css: [
     "vuetify/lib/styles/main.sass",
-    "@mdi/font/css/materialdesignicons.min.css"
+    "@mdi/font/css/materialdesignicons.min.css",
   ],
-  
+
   build: {
-    transpile: ["vuetify"]
-  }
-})
+    transpile: ["vuetify"],
+  },
+});

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "わかめナビ🌱",
+  "short_name": "わかめナビ🌱",
+  "start_url": "/",
+  "display": "standalone",
+  "description": "埼玉大学周辺を走るバスの運行情報を確認することができます。",
+  "background_color": "#eeeeee",
+  "theme_color": "#c8ea50",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "favicon.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
- PWA の第一歩として、 manifest.json を作りました
- ブラウザから URL を打って開かなくても、 (インストールすれば) ホーム画面などから起動することができます
- もしオフラインになったら「オフラインです」と表示されるみたいです
- Windows での動作イメージ 

![image](https://user-images.githubusercontent.com/26807394/235604087-f3dac0c7-2f9c-4c1d-9b2a-4f81a5e40e79.png)
